### PR TITLE
Audit-2 Start

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -132,15 +132,10 @@ module.exports = test(`Deploy Fuel Version 1.0 to ${network_name}`, async t => {
       .getTransaction('0xd21eb619e2e7b1aa0268be9b231e3ff5ba5e732b53ce1525a8e653b503290507'))
       .data;
 
-    console.log(contractCode.length);
-
     // Code produced from deployment.
     const fuelInterface = new ethers.utils.Interface(abi);
     const producedBytecode = fuelInterface.deployFunction
       .encode(bytecode, deploymentParameters);
-
-    // Comparse the two.
-    console.log(contractCode === producedBytecode);
 
     // Assert the bytecode to be the same.
     utils.assert(contractCode === producedBytecode, 'bytecode-verified');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "deploy-goerli": "fuel_v1_network=goerli node ./config/deploy",
     "deploy-kovan": "fuel_v1_network=kovan node ./config/deploy",
     "deploy-mainnet": "fuel_v1_network=mainnet node ./config/deploy",
+    "verify-rinkeby": "fuel_operator=0x0ea6b5edc8905c85514b3676703f1bfe6ec260ad fuel_v1_network=rinkeby verify=1 node ./config/deploy",
     "test-erc20": "npm run build-erc20 && node src/tests/ERC20.test",
     "test-fuel": "npm run build-fuel && node src/tests/",
     "benchmark": "node src/benchmarks/",

--- a/src/Calldata.yulp
+++ b/src/Calldata.yulp
@@ -6,7 +6,16 @@ object "Calldata" {
 
     /// @notice Copy all calldata to memory.
     function calldata.copy() {
+      // Require calldata is available.
+      require(gt(calldatasize(), 0), error"fallback")
+
+      // Copy calldata.
       calldatacopy(_calldata, 0, calldatasize())
+    }
+
+    /// @notice payable requirement, ensure value is not used.
+    function nonpayable() {
+      require(iszero(callvalue()), error"not-payable")
     }
 
     /// @notice Get function signature.

--- a/src/Fraud.yulp
+++ b/src/Fraud.yulp
@@ -28,7 +28,7 @@ object "Fraud" is "Utils", "Block", "Calldata" {
       )
 
       // Check the fraud commitment exists.
-      require(gte(commitmentBlockNumber, 0), "fraud-commitment")
+      require(gt(commitmentBlockNumber, 0), error"fraud-commitment")
 
       // Require that the commitment blockNumber + period >= current block number.
       require(gte(

--- a/src/Fraud.yulp
+++ b/src/Fraud.yulp
@@ -1,9 +1,42 @@
 import "./Block.yulp"
 import "./Utils.yulp"
+import "./Calldata.yulp"
 
 /// @title Fraud proof helper
-object "Fraud" is "Utils", "Block" {
+object "Fraud" is "Utils", "Block", "Calldata" {
   code {
+    /// @dev Fraud finalization period.
+    const FRAUD_FINALIZATION_PERIOD := 10
+
+    /// @notice This will commit a fraud hash in storage.
+    function commitFraudHash(fraudHash) {
+      // We store the caller / fraud hash 5 blocks into the future.
+      sstore(
+        mappingKey2(Storage.FraudCommitments, caller(), fraudHash),
+        number()
+      )
+    }
+
+    /// @notice Ensure that the calldata provided matches the fraud commitment hash.
+    function requireValidFraudCommitment() {
+      // Compute the fraud hash from calldata.
+      let fraudHash := keccak256(_calldata, calldatasize())
+
+      // Get the fraud commitment from block storage.
+      let commitmentBlockNumber := sload(
+        mappingKey2(Storage.FraudCommitments, caller(), fraudHash)
+      )
+
+      // Check the fraud commitment exists.
+      require(gte(commitmentBlockNumber, 0), "fraud-commitment")
+
+      // Require that the commitment blockNumber + period >= current block number.
+      require(gte(
+        number(),
+        add(commitmentBlockNumber, FRAUD_FINALIZATION_PERIOD)
+      ), error"fraud-commitment-hash")
+    }
+
     /// @notice Either assertion must pass or process fraud proof
     function assertOrFraud(assertion, fraudCode, block) {
       // Assert or begin fraud state change sequence

--- a/src/Fuel.yulp
+++ b/src/Fuel.yulp
@@ -129,6 +129,13 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
         return.word(commitAddress(calldata.word(0)))
       }
 
+      /// @notice Register a fraud commitment hash.
+      /// @param fraudHash The hash of the calldata used for a fraud commitment.
+      /// @dev Uses the message sender (caller()) in the commitment.
+      case sig"commitFraudHash(bytes32 fraudHash)" {
+        commitFraudHash(calldata.word(0))
+      }
+
       //////////////////////////////////////////////////////////////////////////
       /// FRAUD PROOFS BEGIN
       //////////////////////////////////////////////////////////////////////////
@@ -162,6 +169,8 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param proofB Second proof.
       /// @dev provers::InvalidInput::proveInvalidInput
       case sig"proveInvalidInput(bytes proofA, bytes proofB) external" {
+        // requireValidFraudCommitment()
+
         let transactionProofA := abi.offset(calldata.word(0))
         let transactionProofB := abi.offset(calldata.word(1))
 
@@ -173,6 +182,8 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param proofB Proof of UTXO being spent again.
       /// @dev provers::DoubleSpend::proveDoubleSpend
       case sig"proveDoubleSpend(bytes proofA, bytes proofB) external" {
+        requireValidFraudCommitment()
+
         let transactionProofA := abi.offset(calldata.word(0))
         let transactionProofB := abi.offset(calldata.word(1))
 
@@ -259,63 +270,6 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
           calldata.word(1)
         )
         return.word(true)
-      }
-
-      /// @notice Extract a UTXO from a proof.
-      /// @param proof Proof.
-      /// @return UTXO data structure.
-      /// @dev Transaction::TransactionProof.UTXO.assign
-      case sig"selectUTXO(bytes proof) external view returns (
-        bytes32 transactionId,
-        uint8 outputIndex,
-        uint8 outputType,
-        address owner,
-        uint256 amount,
-        uint32 token,
-        bytes32 digest,
-        uint256 expiry,
-        address returnOwner)" {
-        TransactionProof.UTXO.assign(abi.offset(calldata.word(0)), 0)
-        return (0, UTXO.size(0))
-      }
-
-      /// @notice Extract an output from a proof.
-      /// @param proof Proof.
-      /// @return The output.
-      /// @dev Transaction::selectOutput
-      case sig"selectOutput(bytes proof) external view returns (bytes output)" {
-        let pos := selectOutput(abi.offset(calldata.word(0)))
-        mstore(sub(pos, 64), 32)
-        mstore(sub(pos, 32), outputSize(pos))
-        return (pos, round32(outputSize(pos)))
-      }
-
-      /// @notice Extract output metadata from a proof.
-      /// @param proof Proof.
-      /// @return The output metadata.
-      /// @dev Transaction::outputMetadata
-      case sig"outputMetadata(bytes proof) external view returns (uint256 metadata)" {
-        let metadata := outputMetadata(abi.offset(calldata.word(0)))
-        return.word(metadata)
-      }
-
-      /// @notice Extract input metadata from a proof.
-      /// @param proof Proof.
-      /// @return The input metadata.
-      /// @dev Transaction::inputMetadata
-      case sig"inputMetadata(bytes proof) external view returns (uint256 metadata)" {
-        let metadata := inputMetadata(abi.offset(calldata.word(0)))
-        return.word(metadata)
-      }
-
-      /// @notice Extract metadata at a given index from a proof.
-      /// @param proof Proof.
-      /// @param index Metadata index.
-      /// @return The metadata.
-      /// @dev Transaction::selectMetadata
-      case sig"selectMetadata(bytes proof, uint8 index) external view returns (bytes8 metadata)" {
-        let pos := selectMetadata(abi.offset(calldata.word(0)), calldata.word(1))
-        return.word(mslice(pos, 8))
       }
 
       /// @notice Get the operator address.

--- a/src/Fuel.yulp
+++ b/src/Fuel.yulp
@@ -80,6 +80,10 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param token Token address.
       /// @dev Deposit::deposit
       case sig"deposit(address account, address token) external" {
+        // Ensure non-payable.
+        nonpayable()
+
+        // Deposit.
         deposit(calldata.word(0), calldata.word(1))
       }
 
@@ -91,6 +95,8 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @dev Root::commitRoot
       case sig"commitRoot(bytes32 merkleTreeRoot, uint256 token,
         uint256 fee, bytes transactions) external" {
+        nonpayable()
+
         commitRoot(calldata.word(0),
           keccak256(abi.offset(calldata.word(3)), abi.length(calldata.word(3))),
           abi.length(calldata.word(3)),
@@ -104,7 +110,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param height Rollup block height.
       /// @param roots List of roots in block.
       /// @dev Block::commitBlock
-      case sig"commitBlock(uint32 minimum, bytes32 minimumHash, uint32 height, bytes32[] roots) external" {
+      case sig"commitBlock(uint32 minimum, bytes32 minimumHash, uint32 height, bytes32[] roots) external payable" {
         commitBlock(
           calldata.word(0),
           calldata.word(1),
@@ -118,6 +124,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param transactionId Transaction ID to authorize.
       /// @dev Witness::commitWitness
       case sig"commitWitness(bytes32 transactionId) external" {
+        nonpayable()
         commitWitness(calldata.word(0))
       }
 
@@ -126,6 +133,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @return New ID assigned to address, or existing ID if already assigned.
       /// @dev Address::commitAddress
       case sig"commitAddress(address addr) external returns (uint256 id)" {
+        nonpayable()
         return.word(commitAddress(calldata.word(0)))
       }
 
@@ -133,6 +141,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param fraudHash The hash of the calldata used for a fraud commitment.
       /// @dev Uses the message sender (caller()) in the commitment.
       case sig"commitFraudHash(bytes32 fraudHash)" {
+        nonpayable()
         commitFraudHash(calldata.word(0))
       }
 
@@ -148,6 +157,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @dev provers::MalformedBlock::proveMalformedBlock
       case sig"proveMalformedBlock(bytes blockHeader, bytes rootHeader,
         uint16 rootIndex, bytes transactions) external" {
+        nonpayable()
         requireValidFraudCommitment()
         let block := abi.offset(calldata.word(0))
         let root := abi.offset(calldata.word(1))
@@ -162,6 +172,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param transactionProof Proof.
       /// @dev provers::InvalidTransaction::proveInvalidTransaction
       case sig"proveInvalidTransaction(bytes transactionProof) external" {
+        nonpayable()
         requireValidFraudCommitment()
         
         proveInvalidTransaction(abi.offset(calldata.word(0)))
@@ -172,6 +183,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param proofB Second proof.
       /// @dev provers::InvalidInput::proveInvalidInput
       case sig"proveInvalidInput(bytes proofA, bytes proofB) external" {
+        nonpayable()
         requireValidFraudCommitment()
 
         let transactionProofA := abi.offset(calldata.word(0))
@@ -185,6 +197,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param proofB Proof of UTXO being spent again.
       /// @dev provers::DoubleSpend::proveDoubleSpend
       case sig"proveDoubleSpend(bytes proofA, bytes proofB) external" {
+        nonpayable()
         requireValidFraudCommitment()
 
         let transactionProofA := abi.offset(calldata.word(0))
@@ -198,6 +211,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param inputProofs Memory offset of start of input proofs.
       /// @dev provers::InvalidWitness::proveInvalidWitness
       case sig"proveInvalidWitness(bytes transactionProof, bytes inputProofs) external" {
+        nonpayable()
         requireValidFraudCommitment()
         proveInvalidWitness(abi.offset(calldata.word(0)), abi.offset(calldata.word(1)))
       }
@@ -207,6 +221,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param inputProofs Memory offset of start of input proofs.
       /// @dev provers::InvalidSum::proveInvalidSum
       case sig"proveInvalidSum(bytes transactionProof, bytes inputProofs) external" {
+        nonpayable()
         requireValidFraudCommitment()
         proveInvalidSum(abi.offset(calldata.word(0)), abi.offset(calldata.word(1)))
       }
@@ -219,6 +234,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param proof Inclusion proof for withdrawal on the rollup chain.
       /// @dev Withdraw::withdraw
       case sig"withdraw(bytes proof) external" {
+        nonpayable()
         withdraw(abi.offset(calldata.word(0)))
       }
 
@@ -226,6 +242,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param blockHeader Rollup block header of block to withdraw bond for.
       /// @dev Withdraw::bondWithdraw
       case sig"bondWithdraw(bytes blockHeader) external" {
+        nonpayable()
         bondWithdraw(abi.offset(calldata.word(0)))
       }
 
@@ -287,14 +304,14 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @notice Get the rollup block height tip.
       /// @return The tip height.
       /// @dev Block::blockTip
-      case sig"blockTip() external view  returns (uint256 blockTip)" {
+      case sig"blockTip() external view returns (uint256 blockTip)" {
         return.word(blockTip())
       }
 
       /// @notice Get number of registered tokens.
       /// @return The number of registered tokens.
       /// @dev Tokens::numTokens
-      case sig"numTokens() external view  returns (uint256 numTokens)" {
+      case sig"numTokens() external view returns (uint256 numTokens)" {
         return.word(numTokens())
       }
 
@@ -302,14 +319,14 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param token Address of token contract.
       /// @return The token ID. 0 if not registered.
       /// @dev Tokens::tokenId
-      case sig"tokenId(address token) external view  returns (uint256 tokenId)" {
+      case sig"tokenId(address token) external view returns (uint256 tokenId)" {
         return.word(tokenId(calldata.word(0)))
       }
 
       /// @notice Get number of registered addresses.
       /// @return The number of registered addresses.
       /// @dev Address::numAddresses
-      case sig"numAddresses() external view  returns (uint256 numAddresses)" {
+      case sig"numAddresses() external view returns (uint256 numAddresses)" {
         return.word(numAddresses())
       }
 
@@ -317,7 +334,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param owner Registered address.
       /// @return The address ID. 0 if not registered.
       /// @dev Address::addressId
-      case sig"addressId(address owner) external view  returns (uint256 addressId)" {
+      case sig"addressId(address owner) external view returns (uint256 addressId)" {
         return.word(addressId(calldata.word(0)))
       }
 
@@ -327,7 +344,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param blockNumber Ethereum block number the deposit was made.
       /// @return The deposit amount. 0 if no deposit made.
       /// @dev Deposit::depositAt
-      case sig"depositAt(address account, uint32 token, uint32 blockNumber) external view  returns (uint256 amount)" {
+      case sig"depositAt(address account, uint32 token, uint32 blockNumber) external view returns (uint256 amount)" {
         return.word(depositAt(
           calldata.word(0),
           calldata.word(1),

--- a/src/Fuel.yulp
+++ b/src/Fuel.yulp
@@ -148,6 +148,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @dev provers::MalformedBlock::proveMalformedBlock
       case sig"proveMalformedBlock(bytes blockHeader, bytes rootHeader,
         uint16 rootIndex, bytes transactions) external" {
+        requireValidFraudCommitment()
         let block := abi.offset(calldata.word(0))
         let root := abi.offset(calldata.word(1))
         let rootIndex := calldata.word(2)
@@ -161,6 +162,8 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param transactionProof Proof.
       /// @dev provers::InvalidTransaction::proveInvalidTransaction
       case sig"proveInvalidTransaction(bytes transactionProof) external" {
+        requireValidFraudCommitment()
+        
         proveInvalidTransaction(abi.offset(calldata.word(0)))
       }
 
@@ -169,7 +172,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param proofB Second proof.
       /// @dev provers::InvalidInput::proveInvalidInput
       case sig"proveInvalidInput(bytes proofA, bytes proofB) external" {
-        // requireValidFraudCommitment()
+        requireValidFraudCommitment()
 
         let transactionProofA := abi.offset(calldata.word(0))
         let transactionProofB := abi.offset(calldata.word(1))
@@ -195,6 +198,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param inputProofs Memory offset of start of input proofs.
       /// @dev provers::InvalidWitness::proveInvalidWitness
       case sig"proveInvalidWitness(bytes transactionProof, bytes inputProofs) external" {
+        requireValidFraudCommitment()
         proveInvalidWitness(abi.offset(calldata.word(0)), abi.offset(calldata.word(1)))
       }
 
@@ -203,6 +207,7 @@ object "Fuel" is "Constructor", "Tokens", "Address" {
       /// @param inputProofs Memory offset of start of input proofs.
       /// @dev provers::InvalidSum::proveInvalidSum
       case sig"proveInvalidSum(bytes transactionProof, bytes inputProofs) external" {
+        requireValidFraudCommitment()
         proveInvalidSum(abi.offset(calldata.word(0)), abi.offset(calldata.word(1)))
       }
 

--- a/src/Root.yulp
+++ b/src/Root.yulp
@@ -6,7 +6,7 @@ import "./Tokens.yulp"
 object "Root" is "Storage", "Tokens" {
   code {
     // Maximum size of list of transactions, in bytes
-    const MAX_ROOT_SIZE := 57600
+    const MAX_ROOT_SIZE := 32000
     // Maximum number of transactions in list of transactions
     const MAX_TRANSACTIONS_IN_ROOT := 2048
 

--- a/src/Storage.yulp
+++ b/src/Storage.yulp
@@ -13,7 +13,8 @@ object "Storage" {
         Token,
         NumAddresses,
         Address,
-        Witness
+        Witness,
+        FraudCommitments
     )
 
     /// @notice Compute storage key for single-element object.

--- a/src/provers/InvalidSum.yulp
+++ b/src/provers/InvalidSum.yulp
@@ -6,6 +6,27 @@ import "./Fraud.yulp"
 /// @title Invalid sum prover
 object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud" {
   code {
+    /// @notice Fraudulant summing, incase of overflow, we conclude fraud.
+    /// @param x The first value to sum.
+    /// @param y The second value to sum.
+    /// @param transactionProof The fraudulant proof incase summing overflows.
+    /// @return z The sum of the two values.
+    function assertAddOrFraud(x, y, transactionProof) -> z {
+      z := add(x, y)
+      assertOrFraud(or(eq(z, x), gt(z, x)), error"summing-overflow", transactionProof)
+    }
+
+    /// @notice Fraudulant multiplying, incase of overflow, we conclude fraud.
+    /// @param x The first value to multiply.
+    /// @param y The second value to multiply.
+    /// @return z The multiple of the two values.
+    function assertMulOrFraud(x, y, transactionProof) -> z {
+      if gt(y, 0) {
+        z := mul(x, y)
+        assertOrFraud(eq(div(z, y), x), error"summing-mul-overflow", transactionProof)
+      }
+    }
+
     /// @notice Compute sum of inputs in token specified in transaction proof.
     /// @param transactionProof Position in memory of transaction proof.
     /// @param inputProofs Position in memory of inputs proofs.
@@ -19,7 +40,7 @@ object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud
 
         case InputType.Transfer {
           if eq(token, UTXO.token(inputProofs)) {
-            sum := add(sum, UTXO.amount(inputProofs))
+            sum := assertAddOrFraud(sum, UTXO.amount(inputProofs), transactionProof)
           }
 
           inputProofs := add(inputProofs, UTXO.size(inputProofs))
@@ -27,7 +48,7 @@ object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud
 
         case InputType.Deposit {
           if eq(token, Deposit.token(inputProofs)) {
-            sum := add(sum, Deposit.value(inputProofs))
+            sum := assertAddOrFraud(sum, Deposit.value(inputProofs), transactionProof)
           }
 
           inputProofs := add(inputProofs, Deposit.size(inputProofs))
@@ -35,7 +56,7 @@ object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud
 
         case InputType.HTLC {
           if eq(token, UTXO.token(inputProofs)) {
-            sum := add(sum, UTXO.amount(inputProofs))
+            sum := assertAddOrFraud(sum, UTXO.amount(inputProofs), transactionProof)
           }
 
           inputProofs := add(inputProofs, UTXO.size(inputProofs))
@@ -43,7 +64,9 @@ object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud
 
         case InputType.Root {
           if eq(token, TransactionProof.feeToken(inputProofs)) {
-            sum := add(sum, mul(TransactionProof.fee(inputProofs), TransactionProof.rootLength(inputProofs)))
+            sum := assertAddOrFraud(sum, 
+              assertMulOrFraud(TransactionProof.fee(inputProofs), TransactionProof.rootLength(inputProofs), transactionProof)
+              , transactionProof)
           }
 
           inputProofs := add(inputProofs, TransactionProof.size(inputProofs))
@@ -69,7 +92,7 @@ object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud
           lt(Output.type(pos), OutputType.Return),
           eq(token, Output.token.slice(pos))
         ) {
-          sum := add(sum, outputAmount(pos))
+          sum := assertAddOrFraud(sum, outputAmount(pos), transactionProof)
         }
 
         pos := add(pos, outputSize(pos))
@@ -81,7 +104,7 @@ object "InvalidSum" is "TransactionProof", "VerifyData", "VerifyWitness", "Fraud
     /// @param inputProofs Position in memory of inputs proofs.
     function proveSum(transactionProof, inputProofs) {
       let token := tokenId(TransactionProof.tokenAddress(transactionProof))
-      let outsum := add(rootFee(transactionProof, token), outs(token, transactionProof))
+      let outsum := assertAddOrFraud(rootFee(transactionProof, token), outs(token, transactionProof), transactionProof)
       let insum := ins(transactionProof, inputProofs)
 
       assertOrFraud(eq(outsum, insum), error"sum", transactionProof)

--- a/src/provers/InvalidTransaction.yulp
+++ b/src/provers/InvalidTransaction.yulp
@@ -151,7 +151,7 @@ object "InvalidTransaction" is "TransactionProof", "Fraud" {
         pos := add(pos, witnessSize(pos))
         index := add(index, 1)
 
-        assertOrFraud(lt(index, INPUTS_MAX), error"witnesses-index-overflow", transactionProof)
+        assertOrFraud(lte(index, INPUTS_MAX), error"witnesses-index-overflow", transactionProof)
       }
 
       assertOrFraud(eq(pos, end), error"witnesses-size-overflow", transactionProof)
@@ -284,7 +284,7 @@ object "InvalidTransaction" is "TransactionProof", "Fraud" {
         pos := add(pos, outputSize(pos))
         index := add(index, 1)
 
-        assertOrFraud(lt(index, OUTPUTS_MAX), error"outputs-index-overflow", transactionProof)
+        assertOrFraud(lte(index, OUTPUTS_MAX), error"outputs-index-overflow", transactionProof)
       }
 
       assertOrFraud(eq(pos, end), error"outputs-size", transactionProof)
@@ -314,7 +314,7 @@ object "InvalidTransaction" is "TransactionProof", "Fraud" {
         index := add(index, 1)
       }
 
-      assertOrFraud(lt(index, INPUTS_MAX), error"inputs-index-overflow", transactionProof)
+      assertOrFraud(lte(index, INPUTS_MAX), error"inputs-index-overflow", transactionProof)
       assertOrFraud(eq(pos, end), error"inputs-size", transactionProof)
     }
 

--- a/src/tests/constructor.js
+++ b/src/tests/constructor.js
@@ -51,6 +51,23 @@ module.exports = test('constructor', async t => { try {
     t.equal(await contract.name(), params[5], 'name');
     t.equal(await contract.version(), params[6], 'version');
 
+    // Fallback
+    await t.revert(t.wallets[0].sendTransaction({
+      to: contract.address,
+      value: 0,
+      gasLimit: 100000,
+    }),
+    errors['fallback'],
+    'fallback no value');
+
+    await t.revert(t.wallets[0].sendTransaction({
+      to: contract.address,
+      value: 1,
+      gasLimit: 100000,
+    }), 
+    errors['fallback'],
+    'fallback with value');
+
     await t.revert(t.wallets[0].sendTransaction({ to: contract.address, data: '0xaa' }),
       errors['invalid-signature'], 'invalid signature');
   };

--- a/src/tests/constructor.js
+++ b/src/tests/constructor.js
@@ -44,7 +44,7 @@ module.exports = test('constructor', async t => { try {
     t.equalBig(await contract.rootBlockNumberAt(utils.emptyBytes32), 0, 'empty root');
     t.equal(await contract.isWithdrawalProcessed(0, utils.emptyBytes32), false, 'empty withdrawal');
     t.equalBig(await contract.SUBMISSION_DELAY(), params[2], 'SUBMISSION_DELAY');
-    t.equalBig(await contract.MAX_ROOT_SIZE(), 57600, 'MAX_ROOT_SIZE');
+    t.equalBig(await contract.MAX_ROOT_SIZE(), 32000, 'MAX_ROOT_SIZE');
     t.equalBig(await contract.BOND_SIZE(), params[4], 'BOND_SIZE');
     t.equalBig(await contract.FINALIZATION_DELAY(), params[1], 'FINALIZATION_DELAY'); // 1 week
     t.equalBig(await contract.PENALTY_DELAY(), params[3], 'PENALTY_DELAY'); // 1 week

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -16,5 +16,6 @@
   await require('./proveMalformedBlock');
   await require('./proveInvalidInput');
   await require('./ownedProxy');
+  await require('./proveComplex');
 
 })();

--- a/src/tests/proveComplex.js
+++ b/src/tests/proveComplex.js
@@ -12,6 +12,11 @@ const { defaults } = require('./harness');
 
 module.exports = test('proveComplex', async t => {
 
+    // Make a transaction in it's own root and block.
+    await function make (opts = {}) {
+        
+    }
+
     // Construct contract
     async function state (opts = {}) {
         const producer = t.wallets[0].address;
@@ -41,6 +46,8 @@ module.exports = test('proveComplex', async t => {
         });
         const etx = await t.wait(contract.deposit(producer, token, overrides),
             'ether deposit', errors);
+
+        
     }
 
     // Empty state.

--- a/src/tests/proveComplex.js
+++ b/src/tests/proveComplex.js
@@ -1,0 +1,49 @@
+/// @dev Prove complex transaction to be valid in summing, witness, input checks.
+const { test, utils, overrides } = require('@fuel-js/environment');
+const { chunk, pack, combine } = require('@fuel-js/struct');
+const { bytecode, abi, errors } = require('../builds/Fuel.json');
+const Proxy = require('../builds/Proxy.json');
+const ERC20 = require('../builds/ERC20.json');
+const { BlockHeader, RootHeader, Leaf,
+    merkleTreeRoot, transactions, hashes } = require('@fuel-js/protocol/src/block');
+const tx = require('@fuel-js/protocol/src/transaction');
+const { Deposit } = require('@fuel-js/protocol/src/deposit');
+const { defaults } = require('./harness');
+
+module.exports = test('proveComplex', async t => {
+
+    // Construct contract
+    async function state (opts = {}) {
+        const producer = t.wallets[0].address;
+        const contract = await t.deploy(abi, bytecode, defaults(producer));
+
+        const totalSupply = utils.bigNumberify('0xFFFFFFFFF');
+        const erc20 = await t.deploy(ERC20.abi, ERC20.bytecode, [producer, totalSupply]);
+
+        let token = utils.emptyAddress;
+        let tokenId = '0x00';
+        let numTokens = 1;
+
+        // try an ether deposit
+        const funnela = await contract.funnel(producer);
+        const valuea = utils.bigNumberify(1000);
+
+        await t.wait(erc20.transfer(funnela, valuea, overrides), 'erc20 transfer');
+        token = erc20.address;
+        tokenId = '0x01';
+        numTokens = 2;
+
+        const deposit = new Deposit({
+            token: tokenId,
+            owner: producer,
+            blockNumber: utils.bigNumberify(await t.getBlockNumber()).add(1),
+            value: valuea,
+        });
+        const etx = await t.wait(contract.deposit(producer, token, overrides),
+            'ether deposit', errors);
+    }
+
+    // Empty state.
+    await state();
+    
+});

--- a/src/tests/proveComplex.js
+++ b/src/tests/proveComplex.js
@@ -252,17 +252,17 @@ module.exports = test('proveComplex', async t => {
         let defaultOuputs = [
             tx.OutputTransfer({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 amount: utils.parseEther('10032.00'),
             }),
             tx.OutputWithdraw({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 amount: utils.parseEther('10032.00'),
             }),
             tx.OutputTransfer({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 amount: utils.parseEther('10032.00'),
             }),
             tx.OutputReturn({
@@ -270,7 +270,7 @@ module.exports = test('proveComplex', async t => {
             }),
             tx.OutputHTLC({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 digest: utils.hexlify(utils.keccak256(defaultPreImage)),
                 returnOwner: '0x01',
                 expiry: 300,
@@ -278,17 +278,17 @@ module.exports = test('proveComplex', async t => {
             }),
             tx.OutputTransfer({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 amount: utils.parseEther('10032.00'),
             }),
             tx.OutputTransfer({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 amount: utils.parseEther('10032.00'),
             }),
             tx.OutputTransfer({
                 token: '0x01',
-                owner: '0x00',
+                owner: producer,
                 amount: utils.parseEther('10032.00'),
             }),
         ];
@@ -604,6 +604,30 @@ module.exports = test('proveComplex', async t => {
                 tx6.proof.encodePacked(),
             ],
         );
+
+        /*
+        proofMain.properties.inputOutputIndex().set(0);
+        proofMain.properties.token()
+            .set(producer);
+        proofMain.properties.selector()
+            .set(producer);
+        await commitFraudProof(
+            'proveInvalidWitness',
+            [
+                proofMain.encodePacked(),
+                chunkJoin([
+                    tx0.proof.encodePacked(),
+                    tx1.proof.encodePacked(),
+                    tx2.proof.encodePacked(),
+                    tx3.proof.encodePacked(),
+                    tx4.proof.encodePacked(),
+                    tx5.proof.encodePacked(),
+                    tx6.proof.encodePacked(), // root
+                    tx7.proof.encode(), // deposit
+                ]),
+            ],
+        );
+        */
 
     }
 

--- a/src/tests/proveDoubleSpend.js
+++ b/src/tests/proveDoubleSpend.js
@@ -137,6 +137,22 @@ module.exports = test('proveDoubleSpend', async t => { try {
       token,
     });
 
+    // Generate the fraud hash
+    const fraudHash = utils.keccak256(contract.interface.functions.proveDoubleSpend.encode(
+      [
+        proof.encodePacked(),
+        proofB.encodePacked(),
+      ],
+    ));
+
+    // Commit the fraud hash.
+    await t.wait(contract.commitFraudHash(fraudHash, {
+      ...overrides,
+    }), 'commit fraud hash', errors);
+
+    // Wait 10 blocks for fraud finalization.
+    await t.increaseBlock(10);
+
     const fraud = await t.wait(contract.proveDoubleSpend(proof.encodePacked(), proofB.encodePacked(), {
       ...overrides,
       value: await contract.BOND_SIZE(),

--- a/src/tests/proveDoubleSpend.js
+++ b/src/tests/proveDoubleSpend.js
@@ -155,7 +155,6 @@ module.exports = test('proveDoubleSpend', async t => { try {
 
     const fraud = await t.wait(contract.proveDoubleSpend(proof.encodePacked(), proofB.encodePacked(), {
       ...overrides,
-      value: await contract.BOND_SIZE(),
     }), 'double spend same deposit', errors);
 
     t.equalBig(await contract.penalty(), (await contract.PENALTY_DELAY()).add(fraud.blockNumber), 'penalty')

--- a/src/tests/proveDoubleSpend.js
+++ b/src/tests/proveDoubleSpend.js
@@ -160,7 +160,6 @@ module.exports = test('proveDoubleSpend', async t => { try {
     t.equalBig(await contract.penalty(), (await contract.PENALTY_DELAY()).add(fraud.blockNumber), 'penalty')
   }
 
-
   await state ({ useErc20: false, attemptDoubleWithdraw: true });
   await state ({ useErc20: true, attemptDoubleWithdraw: true });
 

--- a/src/tests/proveInvalidInput.js
+++ b/src/tests/proveInvalidInput.js
@@ -368,6 +368,24 @@ module.exports = test('proveInvalidInput', async t => { try {
       token,
     });
 
+    /*
+    // Generate the fraud hash
+    const fraudHash = utils.keccak256(contract.interface.functions.proveInvalidInput.encode(
+      [
+        proof,
+        proofB.encodePacked(),
+      ],
+    ));
+
+    // Commit the fraud hash.
+    await t.wait(contract.commitFraudHash(fraudHash, {
+      ...overrides,
+    }), 'commit fraud hash', errors);
+
+    // Wait 10 blocks for fraud finalization.
+    await t.increaseBlock(11);
+    */
+
     if (opts.revert) {
       await t.revert(contract.proveInvalidInput(proof, proofB.encodePacked(), {
         ...overrides,

--- a/src/tests/proveInvalidInput.js
+++ b/src/tests/proveInvalidInput.js
@@ -368,7 +368,6 @@ module.exports = test('proveInvalidInput', async t => { try {
       token,
     });
 
-    /*
     // Generate the fraud hash
     const fraudHash = utils.keccak256(contract.interface.functions.proveInvalidInput.encode(
       [
@@ -383,8 +382,7 @@ module.exports = test('proveInvalidInput', async t => { try {
     }), 'commit fraud hash', errors);
 
     // Wait 10 blocks for fraud finalization.
-    await t.increaseBlock(11);
-    */
+    await t.increaseBlock(10);
 
     if (opts.revert) {
       await t.revert(contract.proveInvalidInput(proof, proofB.encodePacked(), {

--- a/src/tests/proveInvalidSum.js
+++ b/src/tests/proveInvalidSum.js
@@ -146,6 +146,22 @@ module.exports = test('proveInvalidSum', async t => { try {
     const arg1 = proof.encodePacked();
     const arg2 = chunkJoin(outputs.map(v => v.encode()));
 
+    // Generate the fraud hash
+    const fraudHash = utils.keccak256(contract.interface.functions.proveInvalidSum.encode(
+      [
+        arg1,
+        arg2,
+      ],
+    ));
+
+    // Commit the fraud hash.
+    await t.wait(contract.commitFraudHash(fraudHash, {
+      ...overrides,
+    }), 'commit fraud hash', errors);
+
+    // Wait 10 blocks for fraud finalization.
+    await t.increaseBlock(10);
+
     if (!attemptSpendOverflow) {
       const invalidSum = await t.wait(contract.proveInvalidSum(arg1, arg2, {
         ...overrides,

--- a/src/tests/proveInvalidTransaction.js
+++ b/src/tests/proveInvalidTransaction.js
@@ -542,10 +542,9 @@ module.exports = test('proveInvalidTransaction', async t => { try {
     }
 
     // no fraud
-
-    console.log((await t.wait(contract.proveInvalidTransaction(proof.encodePacked(), {
+    await t.wait(contract.proveInvalidTransaction(proof.encodePacked(), {
       ...overrides,
-    }), 'submit valid input transaction', errors)).events[0]);
+    }), 'submit valid input transaction', errors);
     t.equalBig(await contract.blockTip(), 1, 'tip');
   }
 

--- a/src/tests/proveInvalidTransaction.js
+++ b/src/tests/proveInvalidTransaction.js
@@ -506,8 +506,6 @@ module.exports = test('proveInvalidTransaction', async t => { try {
     header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
-
-
     // submit a withdrawal proof
     const proof = tx.TransactionProof({
       block: header,

--- a/src/tests/proveInvalidTransaction.js
+++ b/src/tests/proveInvalidTransaction.js
@@ -434,6 +434,21 @@ module.exports = test('proveInvalidTransaction', async t => { try {
       token,
     });
 
+    // Generate the fraud hash
+    const fraudHash = utils.keccak256(contract.interface.functions.proveInvalidTransaction.encode(
+      [
+        proof.encodePacked()
+      ],
+    ));
+
+    // Commit the fraud hash.
+    await t.wait(contract.commitFraudHash(fraudHash, {
+      ...overrides,
+    }), 'commit fraud hash', errors);
+
+    // Wait 10 blocks for fraud finalization.
+    await t.increaseBlock(10);
+
     if (opts.fraud) {
       const fraudTx = await t.wait(contract.proveInvalidTransaction(proof.encodePacked(), {
         ...overrides,

--- a/src/tests/proveInvalidWitness.js
+++ b/src/tests/proveInvalidWitness.js
@@ -439,6 +439,22 @@ module.exports = test('proveInvalidWitness', async t => {
         });
       }
 
+      // Generate the fraud hash
+      const fraudHash = utils.keccak256(contract.interface.functions.proveInvalidWitness.encode(
+        [
+          proof.encodePacked(),
+          inputs
+        ],
+      ));
+
+      // Commit the fraud hash.
+      await t.wait(contract.commitFraudHash(fraudHash, {
+        ...overrides,
+      }), 'commit fraud hash', errors);
+
+      // Wait 10 blocks for fraud finalization.
+      await t.increaseBlock(10);
+
       if (opts.fraud) {
         const fraudTx = await t.wait(
             contract.proveInvalidWitness(proof.encodePacked(), inputs, {

--- a/src/tests/proveMalformedBlock.js
+++ b/src/tests/proveMalformedBlock.js
@@ -61,6 +61,21 @@ module.exports = test('proveMalformedBlock', async t => { try {
 
       let txr = null;
 
+      // Generate the fraud hash
+      const fraudHash = utils.keccak256(contract.interface.functions.proveMalformedBlock.encode(
+        [
+          ...proofa
+        ],
+      ));
+
+      // Commit the fraud hash.
+      await t.wait(contract.commitFraudHash(fraudHash, {
+        ...overrides,
+      }), 'commit fraud hash', errors);
+
+      // Wait 10 blocks for fraud finalization.
+      await t.increaseBlock(10);
+
       if (opts.fraud) {
         txr = await t.wait(contract.proveMalformedBlock(...proofa, overrides),
           'submit malformed proof', errors);

--- a/src/tests/proveMalformedBlock.js
+++ b/src/tests/proveMalformedBlock.js
@@ -112,7 +112,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
       emptyTx, emptyTx, emptyTx, emptyTx, emptyTx, emptyTx ]);
 
     // valid 500 leafs
-    const leaves = (new Array(500))
+    const leaves = (new Array(150))
       .fill(0)
       .map(v => emptyTx);
 
@@ -120,7 +120,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
     await state(leaves);
 
     // valid 500 leafs, should be 570 eventually
-    const maxValidLeafs = (new Array(560))
+    const maxValidLeafs = (new Array(300))
       .fill(0)
       .map(v => emptyTx);
 
@@ -131,7 +131,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
     const smallChunk = new Leaf({ data: chunk(utils.hexlify(utils.randomBytes(minTransactionSize))) });
 
     // small chunk leaves
-    const smallChunkLeafs = (new Array(560))
+    const smallChunkLeafs = (new Array(320))
       .fill(0)
       .map(v => smallChunk);
 
@@ -142,7 +142,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
     const bigChunk = new Leaf({ data: chunk(utils.hexlify(utils.randomBytes(maxTransactionSize))) });
 
     // state leaves
-    await state((new Array(60))
+    await state((new Array(30))
       .fill(0)
       .map(v => bigChunk));
 
@@ -162,7 +162,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
         }));
 
       let totalLen = 0;
-      const maxLen = 57000;
+      const maxLen = 32000;
       let randomSelectedLeaves = [];
       for (const leaf of randomLeaves) {
         const len = leaf.properties.data().get().length

--- a/src/tests/proveMalformedBlock.js
+++ b/src/tests/proveMalformedBlock.js
@@ -162,7 +162,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
         }));
 
       let totalLen = 0;
-      const maxLen = 32000;
+      const maxLen = 30000;
       let randomSelectedLeaves = [];
       for (const leaf of randomLeaves) {
         const len = leaf.properties.data().get().length


### PR DESCRIPTION
- This commit adds commit / reveal for fraud proofs
- Lowers max root size from 57000 to 32000
- Adds more complex tests for several cases (including more coverage for valid optimistic cases)
- Adds non-payable restrictions to all state changing methods except for commitBlock
- Adds a verification script for rinkeby
- Removes some non-essential selector methods to free up space for additional fraud logic
- Adds overflow protection in the summing proof, where overflow of add or mul is now fraud
- Fixes a selector bug restricting number of selectable outputs to 7, that is now 8